### PR TITLE
Updated to Sorcerer 0.3.0. Clean up code quoting.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source :rubygems
 
-gem 'sorcerer', "~> 0.1.0"
+gem 'sorcerer', "~> 0.3.0"
 gem "rspec", "~> 2.10.0"
 gem "rake", "~> 0.9.2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     rspec-expectations (2.10.0)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.10.1)
-    sorcerer (0.1.0)
+    sorcerer (0.3.0)
 
 PLATFORMS
   ruby
@@ -19,4 +19,4 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 0.9.2.2)
   rspec (~> 2.10.0)
-  sorcerer (~> 0.1.0)
+  sorcerer (~> 0.3.0)

--- a/spec/match_code_helper.rb
+++ b/spec/match_code_helper.rb
@@ -1,5 +1,5 @@
 RSpec::Matchers.define :match_code do |expected|
   match do |actual|
-    actual.should == expected.chomp
+    actual.should == expected
   end
 end

--- a/spec/raffle/refactorings/inline_temp_spec.rb
+++ b/spec/raffle/refactorings/inline_temp_spec.rb
@@ -6,19 +6,21 @@ describe Raffle::Refactorings::InlineTemp do
   context 'when the temp can be safely inlined' do
 
     it 'replaces all uses of the temp' do
-      input = '
-      def thing
-        fred = 35
-        june = fred
-        "I was #{fred} years old"
-      end
-      '
+      input = <<'CODE'
+def thing
+  fred = 35
+  june = fred
+  "I was #{fred} years old"
+  end
+CODE
       output = refactor(input, "fred")
-      output.should == 'def thing
-fred = 35
-june = 35
-"I was #{35} years old"
-end'
+      output.should == <<'CODE'
+def thing
+  fred = 35
+  june = 35
+  "I was #{35} years old"
+end
+CODE
     end
 
     context 'when the temp uses an overloaded name' do

--- a/spec/raffle/refactorings/introduce_temp_spec.rb
+++ b/spec/raffle/refactorings/introduce_temp_spec.rb
@@ -4,15 +4,20 @@ require_relative '../../../lib/raffle/refactorings/introduce_temp'
 describe Raffle::Refactorings::IntroduceTemp do
   it 'extracts the selected code as a temp' do
     pending('discussion of how we select an area of text')
-    input = %{
-    def thing
-      june = 35
-    end
-    }
+    input = <<CODE
+def thing
+  june = 35
+end
+CODE
 
     # should we passing in line number, column number, as well?
     output = refactor(input, convert('35'), 'fred')
 
-    output.should == "def thing\nfred = 35\njune = fred\nend"
+    output.should == <<CODE
+def thing
+  fred = 35
+  june = fred
+end
+CODE
   end
 end

--- a/spec/raffle/refactorings/noop_spec.rb
+++ b/spec/raffle/refactorings/noop_spec.rb
@@ -4,7 +4,7 @@ require 'raffle/refactorings/noop'
 describe Raffle::Refactorings::Noop do
 
   it 'flattens all your lovely indentation (sorry!)' do
-    input = <<-CODE
+    input = <<CODE
 class Foo
   def bar
     [1, 2].each do |baz|
@@ -12,26 +12,30 @@ class Foo
     end
   end
 end
-    CODE
-    output = 'class Foo
-def bar
-[1, 2].each do |baz|
-puts baz
+CODE
+    output = <<CODE
+class Foo
+  def bar
+    [1, 2].each do |baz|
+      puts baz
+    end
+  end
 end
-end
-end'
+CODE
     refactor(input).should == output
   end
 
   it 'respects your funny bracketing conventions' do
-    input = <<-CODE
+    input = <<CODE
 def foo bar
   (bar + (1))
 end
-    CODE
-    output = 'def foo bar
-(bar + (1))
-end'
+CODE
+    output = <<CODE
+def foo bar
+  (bar + (1))
+end
+CODE
     refactor(input).should == output
   end
 end

--- a/spec/raffle/refactorings/remove_unused_temp_spec.rb
+++ b/spec/raffle/refactorings/remove_unused_temp_spec.rb
@@ -3,21 +3,26 @@ require_relative '../../../lib/raffle/refactorings/remove_unused_temp'
 
 describe Raffle::Refactorings::RemoveUnusedTemp do
   let(:input) do
-    %{
-      def thing
-        fred = 35
-        42
-      end
-    }
+    <<CODE
+def thing
+  fred = 35
+  42
+end
+CODE
   end
 
   it 'returns an s-expression with the temp removed' do
-    refactor(input, 'fred').should == "def thing\n42\nend"
+    expected = <<CODE
+def thing
+  42
+end
+CODE
+    refactor(input, 'fred').should == expected
   end
 
   context 'when the temp is not found' do
     it 'returns the s-expression unchanged' do
-      refactor(input, 'jim').should == "def thing\nfred = 35\n42\nend"
+      refactor(input, 'jim').should == "def thing\n  fred = 35\n  42\nend\n"
     end
   end
 

--- a/spec/raffle/refactorings/rename_temp_spec.rb
+++ b/spec/raffle/refactorings/rename_temp_spec.rb
@@ -14,13 +14,13 @@ describe Raffle::Refactorings::RenameTemp do
         fred = "captain"
       end
     }
-    refactor(input, 'fred', 'billy', [3,0]).should match_code <<-CODE
+    refactor(input, 'fred', 'billy', [3,0]).should match_code <<CODE
 def foo
-billy = 45
-june = billy
+  billy = 45
+  june = billy
 end
 def bar
-fred = "captain"
+  fred = "captain"
 end
 CODE
   end
@@ -36,13 +36,13 @@ CODE
           puts thing
         end
       }
-      refactor(input, 'thing', 'bar', [3,0]).should match_code <<-CODE
+      refactor(input, 'thing', 'bar', [3,0]).should match_code <<CODE
 def foo
-bar = 34
-[1].each do |number|
-puts number + bar
-end
-puts bar
+  bar = 34
+  [1].each do |number|
+    puts number + bar
+  end
+  puts bar
 end
 CODE
     end
@@ -57,13 +57,13 @@ CODE
           puts thing
         end
       }
-      refactor(input, 'thing', 'number', [3,0]).should match_code <<-CODE
+      refactor(input, 'thing', 'number', [3,0]).should match_code <<CODE
 def foo
-number = 34
-[1].each do |thing|
-puts thing
-end
-puts number
+  number = 34
+  [1].each do |thing|
+    puts thing
+  end
+  puts number
 end
 CODE
     end
@@ -78,15 +78,17 @@ CODE
           puts thing
         end
       }
-      refactor(input, 'thing', 'number', [5,0]).should match_code <<-CODE
+      result = refactor(input, 'thing', 'number', [5,0])
+      expected = <<CODE
 def foo
-thing = 34
-[1].each do |number|
-puts number
-end
-puts thing
+  thing = 34
+  [1].each do |number|
+    puts number
+  end
+  puts thing
 end
 CODE
+      result.should match_code expected
     end
   end
 
@@ -101,13 +103,13 @@ CODE
           puts thing
         end
       }
-      expected = <<-CODE
+      expected = <<CODE
 def foo
-number = 34
-begin
-number = 35
-end
-puts number
+  number = 34
+  begin
+    number = 35
+  end
+  puts number
 end
 CODE
     refactor(input, 'thing', 'number', [1,0]).should match_code(expected)

--- a/spec/ripper_helper.rb
+++ b/spec/ripper_helper.rb
@@ -13,7 +13,7 @@ module RipperHelper
   end
 
   def rubify(sexpr)
-    Sorcerer.source(sexpr, multiline: true)
+    Sorcerer.source(sexpr, indent: true)
   end
 end
 


### PR DESCRIPTION
Updated raffle to use Sorcerer 0.3.0 which supports indentation on its source code output.  Also updated the code examples in the specs to include (and expect) a terminating newline on each source code refactoring. 

As part of the spec cleanup, I changed the source code quoting to consistently use <<CODE (or <<'CODE') rather that %{} or <<-CODE.  I don't particularly care what style is used, as long as its consistent.
